### PR TITLE
feat(JOML): migrate remaining occurrences

### DIFF
--- a/src/main/java/org/terasology/lost/LevelSpawnSystem.java
+++ b/src/main/java/org/terasology/lost/LevelSpawnSystem.java
@@ -23,8 +23,6 @@ import org.terasology.logic.inventory.InventoryManager;
 import org.terasology.logic.location.LocationComponent;
 import org.terasology.lost.generator.LostWorldGenerator;
 import org.terasology.math.Side;
-import org.terasology.math.geom.ImmutableVector2f;
-import org.terasology.math.geom.Vector2f;
 import org.terasology.polyworld.graph.GraphFacet;
 import org.terasology.polyworld.graph.GraphRegion;
 import org.terasology.registry.In;

--- a/src/main/java/org/terasology/lost/OnSpawnSystem.java
+++ b/src/main/java/org/terasology/lost/OnSpawnSystem.java
@@ -90,7 +90,7 @@ public class OnSpawnSystem extends BaseComponentSystem {
         Vector3i spawnPosition = new Vector3i(x, height, y);
         spawnLevel("Lost:hut", spawnPosition, assetManager, entityManager);
         spawnPosition.y = 0;
-        progressTrackingComponent.hutPosition = JomlUtil.from(spawnPosition);
+        progressTrackingComponent.hutPosition.set(spawnPosition);
 
     }
 }

--- a/src/main/java/org/terasology/lost/ProgressTrackingComponent.java
+++ b/src/main/java/org/terasology/lost/ProgressTrackingComponent.java
@@ -3,8 +3,8 @@
 
 package org.terasology.lost;
 
+import org.joml.Vector3i;
 import org.terasology.entitySystem.Component;
-import org.terasology.math.geom.Vector3i;
 
 import java.util.HashMap;
 

--- a/src/main/java/org/terasology/lost/generator/LostWorldGenerator.java
+++ b/src/main/java/org/terasology/lost/generator/LostWorldGenerator.java
@@ -4,6 +4,7 @@ package org.terasology.lost.generator;
 
 import org.joml.RoundingMode;
 import org.joml.Vector2fc;
+import org.joml.Vector2i;
 import org.joml.Vector3f;
 import org.joml.Vector3fc;
 import org.joml.Vector3i;
@@ -15,10 +16,6 @@ import org.terasology.engine.SimpleUri;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.logic.location.LocationComponent;
 import org.terasology.logic.spawner.FixedSpawner;
-import org.terasology.math.JomlUtil;
-import org.terasology.math.geom.ImmutableVector2f;
-import org.terasology.math.geom.Vector2f;
-import org.terasology.math.geom.Vector2i;
 import org.terasology.polyworld.biome.BiomeModel;
 import org.terasology.polyworld.biome.WhittakerBiome;
 import org.terasology.polyworld.biome.WhittakerBiomeModelFacet;
@@ -156,12 +153,12 @@ public class LostWorldGenerator extends BaseFacetedWorldGenerator {
         Vector2i target;
         if (picker.getClosest() != null) {
             Vector2fc hit = picker.getClosest().getCenter();
-            target = new Vector2i(hit.x(), hit.y());
+            target = new Vector2i(hit.x(), hit.y(), RoundingMode.FLOOR);
         } else {
             target = new Vector2i(desiredPos.x(), desiredPos.z());
         }
 
-        FixedSpawner spawner = new FixedSpawner(target.getX(), target.getY());
+        FixedSpawner spawner = new FixedSpawner(target.x(), target.y());
         return spawner.getSpawnPosition(getWorld(), entity);
     }
 


### PR DESCRIPTION
This removes the last occurrences of `org.terasology.math.geom` from this module :partying_face:

Contributes to MovingBlocks/Terasology#3832