### PR TITLE
refactor: component field visibility public

### DIFF
--- a/src/main/java/org/terasology/lost/ProgressTrackingComponent.java
+++ b/src/main/java/org/terasology/lost/ProgressTrackingComponent.java
@@ -14,11 +14,11 @@ import java.util.HashMap;
  */
 public class ProgressTrackingComponent implements Component<ProgressTrackingComponent> {
     // Biomes mapped to the corresponding level URIs
-    HashMap<String, String> biomeToPrefab = new HashMap<String, String>();
+    public HashMap<String, String> biomeToPrefab = new HashMap<String, String>();
     // To track whether the well has been discovered
-    boolean foundWell;
+    public boolean foundWell;
     // Stores the hut position once it is spawned to prevent overlapping with levels
-    Vector3i hutPosition = new Vector3i();
+    public Vector3i hutPosition = new Vector3i();
 
     public String getLevelPrefab(String biomeName) {
         return biomeToPrefab.get(biomeName);


### PR DESCRIPTION
Newer Java versions are stricter with regards to access restrictions when using reflection.
This affects in particular the serialization of non-public fields in our component classes.
For this reason, we decided to exclude non-public component fields from serialization and refactor all non-public component fields to be public instead to ensure not breaking any game and especially saving/loading behavior.

A future module overhaul may have a more detailed look into the components and make considerate decisions to use non-public fields.

Relates to https://github.com/MovingBlocks/Terasology/pull/5191